### PR TITLE
Convert fee to satoshis in Wallet send method.

### DIFF
--- a/src/logic/wallet.class.js
+++ b/src/logic/wallet.class.js
@@ -101,6 +101,7 @@ class Wallet extends EventEmitter {
     send(btc, address, fee, password) {
 
         const satoshis = Math.round(btc * Constants.Bitcoin.Satoshis);
+        const satoshis_fee = Math.round(fee * Constants.Bitcoin.Satoshis);
 
         const network = bnet.current;
 
@@ -112,12 +113,12 @@ class Wallet extends EventEmitter {
             txb.addInput(utx.tx_hash_big_endian, utx.tx_output_n);
 
             current += utx.value;
-            if (current >= (satoshis + fee)) break;
+            if (current >= (satoshis + satoshis_fee)) break;
         }
 
         txb.addOutput(address, satoshis);
 
-        const change = current - (satoshis + fee);
+        const change = current - (satoshis + satoshis_fee);
         if (change) txb.addOutput(this.address, change);
 
 


### PR DESCRIPTION
I was using this wallet to play around on the testnet but submitting a transaction was always failing. I tracked it down to the `send` method of the `Wallet` class not converting `fee` to satoshis as it does with `btc`.
